### PR TITLE
Changed .reset_all spec & reorganized specs

### DIFF
--- a/spec/owner_spec.rb
+++ b/spec/owner_spec.rb
@@ -8,23 +8,23 @@ describe Owner do
   let(:dog) { Dog.new("Fido") }
 
   context 'Class methods' do
+    it "can initialize an owner" do
+      expect(owner).to be_a(Owner)
+    end
+    
     it "keeps track of the owners that have been created" do
       expect(Owner.all).to include(owner)
     end
 
+    it "can reset the owners that have been created" do
+      Owner.reset_all
+      expect(Owner.class_variable_get(:@@all)).to match([])
+    end
+    
     it "can count how many owners have been created" do
       Owner.reset_all
       Owner.new("human")
       expect(Owner.count).to eq(1)
-    end
-
-    it "can reset the owners that have been created" do
-      Owner.reset_all
-      expect(Owner.count).to eq(0)
-    end
-
-    it "can initialize an owner" do
-      expect(owner).to be_a(Owner)
     end
   end
 


### PR DESCRIPTION
A vast majority of students get very confused with this lab, particularly when their '.count' method in  the Owner specs doesn't pass. This is because most struggle with determining the functionality of the '.reset_all' method, with the way the specs were coded initially. I've simply reorganized the order of the specs and made the purpose of the '.reset_all' method a bit more obvious.